### PR TITLE
체형 이미지 마스킹 API

### DIFF
--- a/src/main/java/com/githubsalt/omoib/bodymasking/controller/BodyMaskingController.java
+++ b/src/main/java/com/githubsalt/omoib/bodymasking/controller/BodyMaskingController.java
@@ -1,0 +1,39 @@
+package com.githubsalt.omoib.bodymasking.controller;
+
+import com.githubsalt.omoib.bodymasking.enums.MaskingType;
+import com.githubsalt.omoib.bodymasking.service.BodyMaskingService;
+import com.githubsalt.omoib.global.dto.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/bodymasking")
+@Slf4j
+@RequiredArgsConstructor
+public class BodyMaskingController {
+
+    private final BodyMaskingService bodyMaskingService;
+
+    @Operation(summary = "바디마스킹 이미지 등록",
+        description = "바디마스킹 이미지를 등록합니다.")
+    @PostMapping("")
+    public ResponseEntity<?> addBodyMaskingImage(@RequestPart MultipartFile image) {
+        Long userId = ((CustomOAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId();
+        bodyMaskingService.addBodyMaskingImage(userId, image);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "바디마스킹 이미지 조회",
+        description = "바디마스킹 이미지를 조회합니다.")
+    @GetMapping("")
+    public ResponseEntity<?> getBodyMaskingImage(@RequestParam MaskingType maskingType) {
+        Long userId = ((CustomOAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId();
+        return ResponseEntity.ok(bodyMaskingService.getBodyMaskingImage(userId, maskingType));
+    }
+
+}

--- a/src/main/java/com/githubsalt/omoib/bodymasking/converter/MaskingTypeConverter.java
+++ b/src/main/java/com/githubsalt/omoib/bodymasking/converter/MaskingTypeConverter.java
@@ -1,0 +1,10 @@
+package com.githubsalt.omoib.bodymasking.converter;
+
+import com.githubsalt.omoib.bodymasking.enums.MaskingType;
+import com.githubsalt.omoib.global.interfaces.GenericEnumConverter;
+
+public class MaskingTypeConverter extends GenericEnumConverter<MaskingType> {
+    public MaskingTypeConverter() {
+        super(MaskingType.class);
+    }
+}

--- a/src/main/java/com/githubsalt/omoib/bodymasking/domain/BodyMasking.java
+++ b/src/main/java/com/githubsalt/omoib/bodymasking/domain/BodyMasking.java
@@ -1,0 +1,36 @@
+package com.githubsalt.omoib.bodymasking.domain;
+
+import com.githubsalt.omoib.bodymasking.enums.MaskingType;
+import com.githubsalt.omoib.bodymasking.converter.MaskingTypeConverter;
+import com.githubsalt.omoib.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BodyMasking {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Convert(converter = MaskingTypeConverter.class)
+    private MaskingType maskingType;
+
+    private String imagePath; // S3 Presigned URL
+
+    @CreationTimestamp
+    @Column(name = "create_at", nullable = false, updatable = false)
+    private LocalDateTime createAt;
+
+}

--- a/src/main/java/com/githubsalt/omoib/bodymasking/enums/MaskingType.java
+++ b/src/main/java/com/githubsalt/omoib/bodymasking/enums/MaskingType.java
@@ -1,0 +1,22 @@
+package com.githubsalt.omoib.bodymasking.enums;
+
+import com.githubsalt.omoib.global.interfaces.ValuedEnum;
+
+public enum MaskingType implements ValuedEnum {
+    SHIRT(1),
+    OUTER(2),
+    PANTS(3),
+    SKIRT(4),
+    DRESS(5);
+
+    private final int value;
+
+    MaskingType(int value) {
+        this.value = value;
+    }
+
+    @Override
+    public Integer getValue() {
+        return this.value;
+    }
+}

--- a/src/main/java/com/githubsalt/omoib/bodymasking/repository/BodyMaskingRepository.java
+++ b/src/main/java/com/githubsalt/omoib/bodymasking/repository/BodyMaskingRepository.java
@@ -1,0 +1,14 @@
+package com.githubsalt.omoib.bodymasking.repository;
+
+import com.githubsalt.omoib.bodymasking.domain.BodyMasking;
+import com.githubsalt.omoib.bodymasking.enums.MaskingType;
+import com.githubsalt.omoib.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BodyMaskingRepository extends JpaRepository<BodyMasking, Long> {
+    Optional<BodyMasking> findByUserAndMaskingType(User user, MaskingType maskingType);
+}

--- a/src/main/java/com/githubsalt/omoib/bodymasking/service/BodyMaskingService.java
+++ b/src/main/java/com/githubsalt/omoib/bodymasking/service/BodyMaskingService.java
@@ -1,0 +1,59 @@
+package com.githubsalt.omoib.bodymasking.service;
+
+import com.githubsalt.omoib.bodymasking.domain.BodyMasking;
+import com.githubsalt.omoib.bodymasking.enums.MaskingType;
+import com.githubsalt.omoib.bodymasking.repository.BodyMaskingRepository;
+import com.githubsalt.omoib.user.domain.User;
+import com.githubsalt.omoib.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class BodyMaskingService {
+
+    private final UserService userService;
+    private final BodyMaskingRepository bodyMaskingRepository;
+
+    public void addBodyMaskingImage(Long userId, MultipartFile image) {
+        User user = userService.findUser(userId).orElseGet(() -> {
+            log.error("User not found. userId: {}", userId);
+            throw new IllegalArgumentException("User not found");
+        });
+
+        Map<MaskingType, String> presignedURL = exchange(image);
+
+        assert presignedURL != null;
+        LocalDateTime now = LocalDateTime.now();
+        for (Map.Entry<MaskingType, String> entry : presignedURL.entrySet()) {
+            bodyMaskingRepository.save(BodyMasking.builder().
+                    user(user).
+                    maskingType(entry.getKey()).
+                    imagePath(entry.getValue()).
+                    createAt(now).
+                    build());
+        }
+    }
+
+    public String getBodyMaskingImage(Long userId, MaskingType maskingType) {
+        return bodyMaskingRepository.findByUserAndMaskingType(
+                        userService.findUser(userId).orElseThrow(), maskingType).orElseThrow().
+                getImagePath();
+    }
+
+    private Map<MaskingType, String> exchange(MultipartFile image) {
+        // TODO
+        // return {MaskingType.SHIRT: "https://s3.presigned.url",
+        //        MaskingType.OUTER: "https://s3.presigned.url",
+        //        MaskingType.PANTS: "https://s3.presigned.url",
+        //        MaskingType.SKIRT: "https://s3.presigned.url",
+        //        MaskingType.DRESS: "https://s3.presigned.url"};
+        return null;
+    }
+}

--- a/src/main/java/com/githubsalt/omoib/review/Review.java
+++ b/src/main/java/com/githubsalt/omoib/review/Review.java
@@ -16,6 +16,9 @@ import lombok.NoArgsConstructor;
 public class Review {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     @OneToOne
     @JoinColumn(name = "history_id") // FK와 PK 역할을 하는 칼럼
     private History history;


### PR DESCRIPTION
# 추가된 기능

- 사용자 체형 이미지 마스킹 API 추가
  - 등록/조회 가능
  - 상의/아우터/하의/치마/드레스(원피스)로 구분
  - LocalDateTime으로 생성 시각 기록
  - 각 마스킹 타입별 S3 Presigned URL 등록
- review 엔티티 구성 관련 버그 수정이 반영되지 않아 다시 처리함 (e04eb24f8f637f7dc50d3f681e815562edd07350)